### PR TITLE
README.md Documentation URL FIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The ZendeskSDK library is used to enable customer service in iOS projects.
 
 ## Documentation
 
-You can find our documentation on https://developer.zendesk.com/embeddables.
+You can find our documentation ![here](https://developer.zendesk.com/documentation/zendesk-web-widget-sdks/sdks/ios/getting_started/).
 
 ## Feature requests and issues
 


### PR DESCRIPTION
The current URL to the iOS documentation site goes to a 404.